### PR TITLE
Fix anchors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ Renders the native picker component on iOS and Android. Example:
 
 ### Props
 
-* [View props...](https://facebook.github.io/react-native/docs/view#props)
+* [Inherited `View` props...](https://facebook.github.io/react-native/docs/view#props)
 
-- [`onValueChange`](README.md#onvaluechange)
-- [`selectedValue`](README.md#selectedvalue)
-- [`style`](README.md#style)
-- [`testID`](README.md#testid)
-- [`enabled`](README.md#enabled)
-- [`mode`](README.md#mode)
-- [`prompt`](README.md#prompt)
-- [`itemStyle`](README.md#itemstyle)
+- [`onValueChange`](#onvaluechange)
+- [`selectedValue`](#selectedvalue)
+- [`style`](#style)
+- [`testID`](#testid)
+- [`enabled`](#enabled)
+- [`mode`](#mode)
+- [`prompt`](#prompt)
+- [`itemStyle`](#itemstyle)
 
 ---
 
@@ -156,11 +156,11 @@ Style to apply to each of the item labels.
 ### PickerIOS
 ### Props
 
-* [View props...](https://facebook.github.io/react-native/docs/view#props)
+* [Inherited `View` props...](https://facebook.github.io/react-native/docs/view#props)
 
-- [`itemStyle`](README.md#itemstyle)
-- [`onValueChange`](README.md#onvaluechange)
-- [`selectedValue`](README.md#selectedvalue)
+- [`itemStyle`](#itemstyle)
+- [`onValueChange`](#onvaluechange)
+- [`selectedValue`](#selectedvalue)
 
 ---
 


### PR DESCRIPTION
# Summary
Currently all anchors in `README.md` cause address change. E.g. `onValueChange` link in [Props section](https://github.com/react-native-community/react-native-picker#props) should lead to
```
https://github.com/react-native-community/react-native-picker#onvaluechange
```
but leads to
```
https://github.com/react-native-community/react-native-picker/blob/master/README.md#onvaluechange
```

This PR fixes that.

## Test Plan
Try clicking on the same link in [Props section with the fix](https://github.com/lebedev/react-native-picker/tree/patch-1#props).