### PR TITLE
Add missing homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-native-community/picker",
   "version": "1.0.0",
+  "homepage": "https://github.com/react-native-community/react-native-picker#readme",
   "description": "React Native Picker for iOS & Android",
   "main": "js/index.js",
   "scripts": {


### PR DESCRIPTION
This was causing the error:
```
[!] The `react-native-cameraroll` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `homepage`.
```