### PR TITLE
Fixed flow errors while RCTPicker is renamed to RNCPicker

### DIFF
--- a/js/PickerIOS.ios.js
+++ b/js/PickerIOS.ios.js
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  *
  *
- * This is a controlled component version of RCTPickerIOS
+ * This is a controlled component version of RNCPickerIOS
  *
  * @format
  * @flow
@@ -64,7 +64,7 @@ type Props = $ReadOnly<{|
 
 type State = {|
   selectedIndex: number,
-  items: $ReadOnlyArray<RCTPickerIOSItemType>,
+  items: $ReadOnlyArray<RNCPickerIOSItemType>,
 |};
 
 type ItemProps = $ReadOnly<{|
@@ -78,7 +78,7 @@ const PickerIOSItem = (props: ItemProps) => {
 };
 
 class PickerIOS extends React.Component<Props, State> {
-  _picker: ?ElementRef<RCTPickerIOSType> = null;
+  _picker: ?ElementRef<RNCPickerIOSType> = null;
 
   state = {
     selectedIndex: 0,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
A flow error is not noticed when RCTPicker is renamed to RNCPicker

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [x] I mentioned this change in `CHANGELOG.md`
- [x] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
