### PR TITLE
Use pod-install in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Read more about autolinking [here](https://github.com/react-native-community/cli
 CocoaPods on iOS needs this extra step
 
 ```
-cd ios && pod install && cd .. 
+npx pod-install
 ```
 
 #### Android


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

We've been recommending devs use `npx pod-install` since it will attempt to install CocoaPods CLI if it's not available on the computer (cite [React Navigation setup guide](https://reactnavigation.org/docs/getting-started/#installing-dependencies-into-a-bare-react-native-project)).

This has proved very useful for Expo users who are now migrating to the bare workflow and want to use this package in their project.

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
