### PR TITLE
[web] Use createElement for elements

### DIFF
--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -11,7 +11,8 @@ import type {
   TextStyleProp,
 } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
-import {StyleSheet} from 'react-native';
+// $FlowFixMe
+import {createElement} from 'react-native';
 import PickerItem from './PickerItem';
 import {forwardRef, useRef} from 'react';
 
@@ -28,13 +29,13 @@ type PickerProps = {
   prompt?: string,
 };
 
+const Select = (props: any) => createElement('select', props);
+
 const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
   const {
     enabled,
     onValueChange,
     selectedValue,
-    style,
-    testID,
     itemStyle,
     mode,
     prompt,
@@ -52,12 +53,10 @@ const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
 
   return (
     // $FlowFixMe
-    <select
+    <Select
       disabled={enabled === false ? true : undefined}
       onChange={handleChange}
       ref={hostRef}
-      style={StyleSheet.flatten([styles.initial, style])}
-      testid={testID}
       value={selectedValue}
       {...other}
     />
@@ -66,12 +65,5 @@ const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
 
 // $FlowFixMe
 Picker.Item = PickerItem;
-
-const styles = StyleSheet.create({
-  initial: {
-    fontFamily: 'System',
-    margin: 0,
-  },
-});
 
 export default Picker;

--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -6,6 +6,8 @@
  */
 
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+// $FlowFixMe
+import {createElement} from 'react-native';
 
 import * as React from 'react';
 
@@ -16,7 +18,8 @@ type Props = {
   value?: number | string,
 };
 
+const Option = (props: any) => createElement('option', props);
+
 export default function PickerItem({color, label, testID, value}: Props) {
-  const style = {color};
-  return <option style={style} testid={testID} value={value} label={label} />;
+  return <Option style={{color}} testID={testID} value={value} label={label} />;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

Using `createElement` will apply RN StyleSheet styles properly and reset the styling. 
This also fixes the `testID` by mapping it to the attribute `data-testid`.

<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅❌     |
| Android |    ✅❌     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [ ] I added a sample use of the API in the example project (`example/App.js`)
