### PR TITLE
fix: example to use its own code

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/picker/ReactDialogPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactDialogPickerManager.java
@@ -19,7 +19,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 @ReactModule(name = ReactDialogPickerManager.REACT_CLASS)
 public class ReactDialogPickerManager extends ReactPickerManager {
 
-  public static final String REACT_CLASS = "AndroidDialogPicker";
+  public static final String REACT_CLASS = "RNCAndroidDialogPicker";
 
   @Override
   public String getName() {

--- a/android/src/main/java/com/reactnativecommunity/picker/ReactDropdownPickerManager.java
+++ b/android/src/main/java/com/reactnativecommunity/picker/ReactDropdownPickerManager.java
@@ -18,7 +18,7 @@ import com.facebook.react.uimanager.ThemedReactContext;
 @ReactModule(name = ReactDropdownPickerManager.REACT_CLASS)
 public class ReactDropdownPickerManager extends ReactPickerManager {
 
-  public static final String REACT_CLASS = "AndroidDropdownPicker";
+  public static final String REACT_CLASS = "RNCAndroidDropdownPicker";
 
   @Override
   public String getName() {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -191,6 +191,7 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "com.facebook.react:react-native:+"  // From node_modules
+    implementation project(":@react-native-community_picker")
 
     if (enableHermes) {
         def hermesPath = "../../../node_modules/hermes-engine/android/";

--- a/example/android/app/src/main/java/com/pickerexample/MainApplication.java
+++ b/example/android/app/src/main/java/com/pickerexample/MainApplication.java
@@ -7,32 +7,33 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+import com.reactnativecommunity.picker.RNCPickerPackage;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 public class MainApplication extends Application implements ReactApplication {
 
-  private final ReactNativeHost mReactNativeHost =
-      new ReactNativeHost(this) {
-        @Override
-        public boolean getUseDeveloperSupport() {
-          return BuildConfig.DEBUG;
-        }
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+    @Override
+    public boolean getUseDeveloperSupport() {
+      return BuildConfig.DEBUG;
+    }
 
-        @Override
-        protected List<ReactPackage> getPackages() {
-          @SuppressWarnings("UnnecessaryLocalVariable")
-          List<ReactPackage> packages = new PackageList(this).getPackages();
-          // Packages that cannot be autolinked yet can be added manually here, for example:
-          // packages.add(new MyReactNativePackage());
-          return packages;
-        }
+    @Override
+    protected List<ReactPackage> getPackages() {
+      @SuppressWarnings("UnnecessaryLocalVariable")
+      List<ReactPackage> packages = new PackageList(this).getPackages();
+      // Packages that cannot be autolinked yet can be added manually here, for
+      // example: packages.add(new MyReactNativePackage());
+      packages.add(new RNCPickerPackage());
+      return packages;
+    }
 
-        @Override
-        protected String getJSMainModuleName() {
-          return "example/index";
-        }
-      };
+    @Override
+    protected String getJSMainModuleName() {
+      return "example/index";
+    }
+  };
 
   @Override
   public ReactNativeHost getReactNativeHost() {
@@ -43,7 +44,8 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
-    initializeFlipper(this); // Remove this line if you don't want Flipper enabled
+    initializeFlipper(
+        this); // Remove this line if you don't want Flipper enabled
   }
 
   /**
@@ -58,8 +60,10 @@ public class MainApplication extends Application implements ReactApplication {
          We use reflection here to pick up the class that initializes Flipper,
         since Flipper library is not available in release mode
         */
-        Class<?> aClass = Class.forName("com.facebook.flipper.ReactNativeFlipper");
-        aClass.getMethod("initializeFlipper", Context.class).invoke(null, context);
+        Class<?> aClass =
+            Class.forName("com.facebook.flipper.ReactNativeFlipper");
+        aClass.getMethod("initializeFlipper", Context.class)
+            .invoke(null, context);
       } catch (ClassNotFoundException e) {
         e.printStackTrace();
       } catch (NoSuchMethodException e) {

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -2,4 +2,7 @@ rootProject.name = 'PickerExample'
 
 apply from: file("../../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 
+include ':@react-native-community_picker'
+project(':@react-native-community_picker').projectDir = new File(rootProject.projectDir, 	'../../android')
+
 include ':app'

--- a/js/AndroidDialogPickerNativeComponent.js
+++ b/js/AndroidDialogPickerNativeComponent.js
@@ -43,5 +43,5 @@ type NativeProps = $ReadOnly<{|
 type DialogPickerNativeType = Class<NativeComponent<NativeProps>>;
 
 module.exports = ((requireNativeComponent(
-  'AndroidDialogPicker',
+  'RNCAndroidDialogPicker',
 ): any): DialogPickerNativeType);

--- a/js/PickerAndroid.android.js
+++ b/js/PickerAndroid.android.js
@@ -14,10 +14,10 @@ import React from 'react';
 import {processColor, requireNativeComponent, StyleSheet} from 'react-native';
 
 const AndroidDropdownPickerNativeComponent = requireNativeComponent(
-  'AndroidDropdownPicker',
+  'RNCAndroidDropdownPicker',
 );
 const AndroidDialogPickerNativeComponent = requireNativeComponent(
-  'AndroidDialogPicker',
+  'RNCAndroidDialogPicker',
 );
 
 const REF_PICKER = 'picker';


### PR DESCRIPTION
This PR makes some addition to PR #99 

Since the example package previously relied on AndroidDialogPicker and AndroidDropdownPicker from the Core React Native Package, I've included the RNCPicker manually to the example, so that Android example actually uses the java code from this repository.