### PR TITLE
chore: remove changelog in favor of releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,0 @@
-## [1.1.1](https://github.com/react-native-community/react-native-picker/compare/v1.1.0...v1.1.1) (2019-09-22)
-
-### Bug Fixes
-
-* podspec file to match the expections of Cocoapods. ([332774c](https://github.com/react-native-community/react-native-picker/commit/332774c))


### PR DESCRIPTION
Fixes #81 

Removing Changelog.md in favor of https://github.com/react-native-community/react-native-picker/releases, since the changelog isn't being maintained