### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Add `PackageProviders().Append(winrt::ReactNativePicker::ReactPackageProvider())
   	```
 3. Insert the following lines inside the dependencies block in `android/app/build.gradle`:
   	```
-      compile project(': @react-native-community/picker')
+      implementation project(path: ':@react-native-community_picker')
   	```
 
 


### PR DESCRIPTION
`compile` is deprecated

# Summary
I had to update this statement to get it to work in my app.

## Test Plan
When I used `compile`, my app did not work. I changed it to this statement and it worked.

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    N/A  |
| Android |    ✅    |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [X] I have tested this on a device and a simulator
- [X] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` - not sure if this warrants a change to the changelog
- [ ] I updated the typed files (TS and Flow) - N/A
- [ ] I added a sample use of the API in the example project (`example/App.js`) -N/A
