### PR TITLE
fix: Fixed web with newer RN versions

### DIFF
--- a/js/Picker.web.js
+++ b/js/Picker.web.js
@@ -12,7 +12,7 @@ import type {
 } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type {ViewProps} from 'react-native/Libraries/Components/View/ViewPropTypes';
 // $FlowFixMe
-import {createElement} from 'react-native';
+import {createElement, unstable_createElement} from 'react-native';
 import PickerItem from './PickerItem';
 import {forwardRef, useRef} from 'react';
 
@@ -29,7 +29,9 @@ type PickerProps = {
   prompt?: string,
 };
 
-const Select = (props: any) => createElement('select', props);
+const myCreateElement = createElement || unstable_createElement;
+
+const Select = (props: any) => myCreateElement('select', props);
 
 const Picker = forwardRef<PickerProps, *>((props, forwardedRef) => {
   const {

--- a/js/PickerItem.js
+++ b/js/PickerItem.js
@@ -6,8 +6,9 @@
  */
 
 import type {ColorValue} from 'react-native/Libraries/StyleSheet/StyleSheetTypes';
+
 // $FlowFixMe
-import {createElement} from 'react-native';
+import {createElement, unstable_createElement} from 'react-native';
 
 import * as React from 'react';
 
@@ -18,7 +19,9 @@ type Props = {
   value?: number | string,
 };
 
-const Option = (props: any) => createElement('option', props);
+const myCreateElement = createElement || unstable_createElement;
+
+const Option = (props: any) => myCreateElement('option', props);
 
 export default function PickerItem({color, label, testID, value}: Props) {
   return <Option style={{color}} testID={testID} value={value} label={label} />;


### PR DESCRIPTION
Since react-native-web 0.12, `createElement` was renamed to `unstable_createElement`.

Closes  issue #103 
